### PR TITLE
fix: Remove erroneous non-dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
   "description": "Compose example objects",
   "license": "MIT",
   "require": {
-    "php": "^8.1",
-    "dq5studios/psalm-junit": "^2.0"
+    "php": "^8.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.3",
     "vimeo/psalm": "^4.3",
-    "squizlabs/php_codesniffer": "^3.5"
+    "squizlabs/php_codesniffer": "^3.5",
+    "dq5studios/psalm-junit": "^2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The dependency on `dq5studios/psalm-junit` belongs in development.